### PR TITLE
Features/simplify auth check

### DIFF
--- a/ProcessCommunication/AdminGroupManipulator.cs
+++ b/ProcessCommunication/AdminGroupManipulator.cs
@@ -154,6 +154,47 @@ namespace SinclairCC.MakeMeAdmin
         }
 
 
+
+        /// <summary>
+        /// Determines whether the given array of SIDs/Identities contains the given target user identity.
+        /// </summary>
+        /// <param name="accountList">
+        /// An array to be searched for the target identity.
+        /// </param>
+        /// <param name="userIdentity">
+        /// The user identity to check to see if they or one of the groups they belong to are in the list of identities.
+        /// </param>
+        /// <returns>
+        /// Returns true if the given target identity is present in the array of SIDs/Identities.
+        /// If the array is null or empty, false is returned.
+        /// </returns>
+        private static bool AccountListContainsIdentity(string[] accountList, WindowsIdentity userIdentity)
+        {
+            if (accountList != null)
+            {
+                foreach (var sid in accountList)
+                {
+                    // If the user's SID or name is in the list, return true
+                    if (LocalAdministratorGroup.GetSIDFromAccountName(sid) == userIdentity.User)
+                    {
+                        return true;
+                    }
+
+                    // If any of the user's authorization groups are in the denied list, the user is not authorized.
+                    foreach (IdentityReference groupsid in userIdentity.Groups)
+                    {
+                        // Translate the NT Account (Domain\User) to SID if needed, and check the resulting values.
+                        if (LocalAdministratorGroup.GetSIDFromAccountName(sid) == (SecurityIdentifier)groupsid.Translate(typeof(SecurityIdentifier)))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+
         /// <summary>
         /// Determines whether the given user is authorized to obtain administrator rights.
         /// </summary>
@@ -183,30 +224,10 @@ namespace SinclairCC.MakeMeAdmin
                 return false;
             }
 
-            if ((deniedSidsList != null) && (deniedSidsList.Length > 0))
-            { // The denied list contains entries. Check the user against that list first.
-
-                // If the user's SID or name is in the denied list, the user is not authorized.
-                if ((ArrayContainsString(deniedSidsList, userIdentity.User.Value)) || (ArrayContainsString(deniedSidsList, userIdentity.Name)))
-                {
-                    return false;
-                }
-
-                // If any of the user's authorization groups are in the denied list, the user is not authorized.
-                foreach (SecurityIdentifier sid in userIdentity.Groups)
-                {
-                    // Check the SID values.
-                    if (ArrayContainsString(deniedSidsList, sid.Value))
-                    {
-                        return false;
-                    }
-
-                    // Translate the SID to an NT Account (Domain\User), and check the resulting values.
-                    if (ArrayContainsString(deniedSidsList, LocalAdministratorGroup.GetAccountNameFromSID(sid)))
-                    {
-                        return false;
-                    }
-                }
+            // The denied list contains entries. Check the user against that list first.
+            if ((deniedSidsList != null) && AccountListContainsIdentity(deniedSidsList, userIdentity))
+            { 
+                return false;
             }
 
             // The user hasn't been denied yet, so now we check for authorization.
@@ -222,27 +243,9 @@ namespace SinclairCC.MakeMeAdmin
             }
             else
             { // The allowed list has entries.
-
-                // If the user's SID is in the allowed list, the user is authorized.
-                if ((ArrayContainsString(allowedSidsList, userIdentity.User.Value)) || (ArrayContainsString(allowedSidsList, userIdentity.Name)))
+                if (AccountListContainsIdentity(allowedSidsList, userIdentity))
                 {
                     return true;
-                }
-
-                // If any of the user's authorization groups are in the allowed list, the user is authorized.
-                foreach (SecurityIdentifier sid in userIdentity.Groups)
-                {
-                    // Check the SID values.
-                    if (ArrayContainsString(allowedSidsList, sid.Value))
-                    {
-                        return true;
-                    }
-
-                    // Translate the SID to an NT Account (Domain\User), and check the resulting values.
-                    if (ArrayContainsString(allowedSidsList, LocalAdministratorGroup.GetAccountNameFromSID(sid)))
-                    {
-                        return true;
-                    }
                 }
 
                 // The user was not found in the allowed list, so the user is not authorized.

--- a/ProcessCommunication/AdminGroupManipulator.cs
+++ b/ProcessCommunication/AdminGroupManipulator.cs
@@ -121,40 +121,6 @@ namespace SinclairCC.MakeMeAdmin
 
 
 
-
-        /// <summary>
-        /// Determines whether the given array of strings contains the given target string.
-        /// </summary>
-        /// <param name="stringArray">
-        /// An array to be searched for the target string.
-        /// </param>
-        /// <param name="targetString">
-        /// The string to be searched for in the array.
-        /// </param>
-        /// <returns>
-        /// Returns true if the given target string is present in the array.
-        /// If the array is null or empty, false is returned.
-        /// </returns>
-        /// <remarks>
-        /// String comparisons are case-insensitive.
-        /// </remarks>
-        private static bool ArrayContainsString(string[] stringArray, string targetString)
-        {
-            if ((stringArray != null) && (stringArray.Length > 0))
-            {
-                for (int i = 0; i < stringArray.Length; i++)
-                {
-                    if (string.Compare(System.Environment.ExpandEnvironmentVariables(stringArray[i]), targetString, System.Globalization.CultureInfo.CurrentCulture, System.Globalization.CompareOptions.IgnoreCase) == 0)
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-
-
         /// <summary>
         /// Determines whether the given array of SIDs/Identities contains the given target user identity.
         /// </summary>

--- a/ProcessCommunication/AdminGroupManipulator.cs
+++ b/ProcessCommunication/AdminGroupManipulator.cs
@@ -138,10 +138,12 @@ namespace SinclairCC.MakeMeAdmin
         {
             if (accountList != null)
             {
-                foreach (var sid in accountList)
+                foreach (var account in accountList)
                 {
+                    var sid = LocalAdministratorGroup.GetSIDFromAccountName(account);
+
                     // If the user's SID or name is in the list, return true
-                    if (LocalAdministratorGroup.GetSIDFromAccountName(sid) == userIdentity.User)
+                    if (sid == userIdentity.User)
                     {
                         return true;
                     }
@@ -150,7 +152,7 @@ namespace SinclairCC.MakeMeAdmin
                     foreach (IdentityReference groupsid in userIdentity.Groups)
                     {
                         // Translate the NT Account (Domain\User) to SID if needed, and check the resulting values.
-                        if (LocalAdministratorGroup.GetSIDFromAccountName(sid) == (SecurityIdentifier)groupsid.Translate(typeof(SecurityIdentifier)))
+                        if (sid == (SecurityIdentifier)groupsid.Translate(typeof(SecurityIdentifier)))
                         {
                             return true;
                         }

--- a/ProcessCommunication/LocalAdministratorGroup.cs
+++ b/ProcessCommunication/LocalAdministratorGroup.cs
@@ -485,20 +485,9 @@ namespace SinclairCC.MakeMeAdmin
         {
             try
             {
-                string sidPattern = @"^S-\d-\d+-(\d+-){1,14}\d+$";
-                bool isSid = System.Text.RegularExpressions.Regex.IsMatch(accountname, sidPattern);
-
-                if (isSid)
-                {
-                    return new SecurityIdentifier(accountname);
-                }
-                else
-                {
-                    NTAccount account = new NTAccount(accountname);
-                    var sid = (SecurityIdentifier)account.Translate(typeof(SecurityIdentifier));
-                    return sid;
-
-                }
+                PrincipalContext pc = new PrincipalContext(ContextType.Machine);
+                GroupPrincipal gp = GroupPrincipal.FindByIdentity(pc, accountname);
+                return gp?.Sid;
             }
             catch (IdentityNotMappedException)
             { // Some or all identity references could not be translated.

--- a/ProcessCommunication/LocalAdministratorGroup.cs
+++ b/ProcessCommunication/LocalAdministratorGroup.cs
@@ -485,7 +485,7 @@ namespace SinclairCC.MakeMeAdmin
         {
             try
             {
-                PrincipalContext pc = new PrincipalContext(ContextType.Machine);
+                PrincipalContext pc = LocalMachineContext;
                 GroupPrincipal gp = GroupPrincipal.FindByIdentity(pc, accountname);
                 return gp?.Sid;
             }

--- a/ProcessCommunication/LocalAdministratorGroup.cs
+++ b/ProcessCommunication/LocalAdministratorGroup.cs
@@ -471,6 +471,53 @@ namespace SinclairCC.MakeMeAdmin
         }
 
 
+        /// <summary>
+        /// Gets the security identifier (SID) corresponding to a given sid string or account name.
+        /// </summary>
+        /// <param name="accountname">
+        /// The SID string or account name that the SID should be retrieved for.
+        /// </param>
+        /// <returns>
+        /// Returns a security identifier (SID) corresponding to a given sid string or account name.
+        /// If the account name doesn't exist, null is returned.
+        /// </returns>
+        internal static SecurityIdentifier GetSIDFromAccountName(string accountname)
+        {
+            try
+            {
+                string sidPattern = @"^S-\d-\d+-(\d+-){1,14}\d+$";
+                bool isSid = System.Text.RegularExpressions.Regex.IsMatch(accountname, sidPattern);
+
+                if (isSid)
+                {
+                    return new SecurityIdentifier(accountname);
+                }
+                else
+                {
+                    NTAccount account = new NTAccount(accountname);
+                    var sid = (SecurityIdentifier)account.Translate(typeof(SecurityIdentifier));
+                    return sid;
+
+                }
+            }
+            catch (IdentityNotMappedException)
+            { // Some or all identity references could not be translated.
+                return null;
+            }
+            catch (System.ArgumentNullException)
+            { // The target translation type is null.
+                return null;
+            }
+            catch (System.ArgumentException)
+            { // The target translation type is not an IdentityReference type.
+                return null;
+            }
+            catch (System.SystemException)
+            { // A Win32 error code was returned.
+                return null;
+            }
+        }
+
         /*
         public static bool CurrentUserIsMember()
         {

--- a/ProcessCommunication/LocalAdministratorGroup.cs
+++ b/ProcessCommunication/LocalAdministratorGroup.cs
@@ -22,6 +22,7 @@ namespace SinclairCC.MakeMeAdmin
 {
     using System;
     using System.DirectoryServices.AccountManagement;
+    using System.Linq;
     using System.Security.Principal;
 
     /// <summary>
@@ -33,17 +34,17 @@ namespace SinclairCC.MakeMeAdmin
         /// The context against which all operations are performed by this class.
         /// In this case, the context is the local machine.
         /// </summary>
-        private static PrincipalContext localMachineContext = null;
+        //private static PrincipalContext localMachineContext = null;
 
         /// <summary>
         /// The security identifier (SID) of the local Administrators group.
         /// </summary>
-        private static SecurityIdentifier localAdminsGroupSid = null;
+        private static SecurityIdentifier _localAdminsGroupSid = null;
 
         /// <summary>
         /// Represents the local Administrators group.
         /// </summary>
-        private static GroupPrincipal localAdminGroup = null;
+        //private static GroupPrincipal localAdminGroup = null;
 
         /// <summary>
         /// Constructor.
@@ -55,7 +56,7 @@ namespace SinclairCC.MakeMeAdmin
         /// <summary>
         /// Gets a context representing the local machine.
         /// </summary>
-        private static PrincipalContext LocalMachineContext
+        /*private static PrincipalContext LocalMachineContext
         {
             get
             {
@@ -78,7 +79,7 @@ namespace SinclairCC.MakeMeAdmin
                 }
                 return localMachineContext;
             }
-        }
+        }*/
 
         /// <summary>
         /// Gets the security identifier (SID) of the local Administrators group.
@@ -87,11 +88,11 @@ namespace SinclairCC.MakeMeAdmin
         {
             get
             {
-                if (localAdminsGroupSid == null)
+                if (_localAdminsGroupSid == null)
                 {
-                    localAdminsGroupSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+                    _localAdminsGroupSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
                 }
-                return localAdminsGroupSid;
+                return _localAdminsGroupSid;
             }
         }
 
@@ -100,13 +101,16 @@ namespace SinclairCC.MakeMeAdmin
         /// </summary>
         public static string LocalAdminGroupName
         {
-            get { return LocalAdminGroup.Name; }
+            get {
+                var localAdminGroupNTAccount = LocalAdminsGroupSid.Translate(typeof(NTAccount));
+                return localAdminGroupNTAccount?.Value.Split('\\').ElementAtOrDefault(1);
+            }
         }
 
         /// <summary>
         /// Gets an object representing the local Administrators group.
         /// </summary>
-        private static GroupPrincipal LocalAdminGroup
+        /*private static GroupPrincipal LocalAdminGroup
         {
             get
             {
@@ -138,7 +142,7 @@ namespace SinclairCC.MakeMeAdmin
                 }
                 return localAdminGroup;
             }
-        }
+        }*/
 
         /// <summary>
         /// Adds a user to the local Administrators group.
@@ -165,7 +169,7 @@ namespace SinclairCC.MakeMeAdmin
             }
 
             if (
-                (LocalAdminGroup != null) &&
+                (LocalAdminGroupName != null) &&
                 (userIdentity.User != null) && 
                 (userIdentity.Groups != null) && 
                 (userIsAuthorized)
@@ -187,7 +191,7 @@ namespace SinclairCC.MakeMeAdmin
         /// </param>
         private static bool AddUserToAdministrators(SecurityIdentifier userSid)
         {
-            int result = AddLocalGroupMembers(LocalAdminGroup.SamAccountName, userSid);
+            int result = AddLocalGroupMembers(LocalAdminGroupName, userSid);
             if (result == 0)
             {
                 ApplicationLog.WriteEvent(string.Format(Properties.Resources.UserAddedToAdminsGroup, userSid, GetAccountNameFromSID(userSid)), EventID.UserAddedToAdminsSuccess, System.Diagnostics.EventLogEntryType.Information);
@@ -213,16 +217,16 @@ namespace SinclairCC.MakeMeAdmin
         {
             // TODO: Only do this if the user is a member of the group?
 
-            if ((LocalAdminGroup != null) && (userSid != null))
+            if ((LocalAdminGroupName != null) && (userSid != null))
             {
-                SecurityIdentifier[] localAdminSids = GetLocalGroupMembers(LocalAdminGroup.SamAccountName);
+                SecurityIdentifier[] localAdminSids = GetLocalGroupMembers(LocalAdminGroupName);
 
                 foreach (SecurityIdentifier sid in localAdminSids)
                 {
                     if (sid == userSid)
                     {
                         string accountName = GetAccountNameFromSID(userSid);
-                        int result = RemoveLocalGroupMembers(LocalAdminGroup.SamAccountName, userSid);
+                        int result = RemoveLocalGroupMembers(LocalAdminGroupName, userSid);
                         if (result == 0)
                         {
                             EncryptedSettings encryptedSettings = new EncryptedSettings(EncryptedSettings.SettingsFilePath);
@@ -268,9 +272,9 @@ namespace SinclairCC.MakeMeAdmin
 
             // Get a list of the current members of the Administrators group.
             SecurityIdentifier[] localAdminSids = null;
-            if ((addedUserList.Length > 0) && (LocalAdminGroup != null))
+            if ((addedUserList.Length > 0) && (LocalAdminGroupName != null))
             {
-                localAdminSids = GetLocalGroupMembers(LocalAdminGroup.SamAccountName);
+                localAdminSids = GetLocalGroupMembers(LocalAdminGroupName);
             }
 
             for (int i = 0; i < addedUserList.Length; i++)
@@ -655,7 +659,7 @@ namespace SinclairCC.MakeMeAdmin
         /// </remarks>
         public static bool IsMemberOfAdministratorsDirectly(WindowsIdentity userIdentity)
         {
-            SecurityIdentifier[] localAdminSids = GetLocalGroupMembers(LocalAdminGroup.SamAccountName);
+            SecurityIdentifier[] localAdminSids = GetLocalGroupMembers(LocalAdminGroupName);
 
             bool isMember = false;
 
@@ -685,7 +689,7 @@ namespace SinclairCC.MakeMeAdmin
 
             if (!isMember)
             {
-                SecurityIdentifier[] localAdminSids = GetLocalGroupMembers(LocalAdminGroup.SamAccountName);
+                SecurityIdentifier[] localAdminSids = GetLocalGroupMembers(LocalAdminGroupName);
 
                 // We can't use userIdentity.Groups here, because it does not include group memberships
                 // that are used for deny-only.


### PR DESCRIPTION
These changes switch around the checks against allow-list and deny-list to convert the names on the list to SIDs and compare these to the user identity rather than coverting the SIDs in the user identity to names and comparing to the lists.

This is faster if the user is a member of a lot of groups and means you can use names in the allow-list and deny-list without adding the local computer name, e.g. "MakeMeAdminAllowed" instead of "MACHINENAME\MakeMeAdminAllowed". 

The IsMemberOfAdministratorsDirectly and IsMemberOfAdministrators functions have also been changed to use a different method of getting the Local Administrators Group Name because using GroupPrincipal for this ends up doing lots of unnecessary network traffic to gather details about group members and adds from 2s to 15s to the check for us. 

With both these changes, the admin group check becomes virtually instantaneous and can be completed in a fraction of a second. 

Finally, localAdminsGroupSid was renamed to _localAdminsGroupSid to better show that it is a backing variable and should never be accessed directly except in the property getter. 



