### PR TITLE
Make event log source consistent between service start/stop and event…

### DIFF
--- a/Enumerations/EventID.cs
+++ b/Enumerations/EventID.cs
@@ -26,6 +26,11 @@ namespace SinclairCC.MakeMeAdmin
     public enum EventID : int
     {
         /// <summary>
+        /// The built-in service functionality uses Event ID 0 to log service start/stop events.
+        /// </summary>
+        ServiceStartStop,
+
+        /// <summary>
         /// A user was added to the Administrators group.
         /// </summary>
         UserAddedToAdminsSuccess,

--- a/Logging/ApplicationLog.cs
+++ b/Logging/ApplicationLog.cs
@@ -30,7 +30,7 @@ namespace SinclairCC.MakeMeAdmin
         /// <summary>
         /// The source name to use when writing events to the Event Log.
         /// </summary>
-        private const string SourceName = "Make Me Admin";        
+        private const string SourceName = "MakeMeAdmin";        
 
         /// <summary>
         /// An EventLog object for interacting with this service's event log.


### PR DESCRIPTION
At the moment, service start and stop events get logged as "MakeMeAdmin", but events from the service get logged as "Make Me Admin". It would be nice to make these consistent and use one source name. 