### PR TITLE
Factor out common AssemblyInfo

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // Copyright © 2010-2019, Sinclair Community College
 // Licensed under the GNU General Public License, version 3.
 // See the LICENSE file in the project root for full license information.  
@@ -25,8 +25,28 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Make Me Admin Process Communication Library")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Sinclair Community College")]
+[assembly: AssemblyProduct("Make Me Admin")]
+[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("7695c82b-4f13-4d07-9eb1-8259dbeb1be7")]
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: NeutralResourcesLanguage("en-US")]

--- a/Enumerations/Enumerations.csproj
+++ b/Enumerations/Enumerations.csproj
@@ -61,6 +61,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogElevatedProcesses.cs" />
     <Compile Include="EventID.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Enumerations/Properties/AssemblyInfo.cs
+++ b/Enumerations/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin Enumerations Library")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5fb1809b-b0fd-48e9-9e47-3cb048369433")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/Logging/Logging.csproj
+++ b/Logging/Logging.csproj
@@ -94,6 +94,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ElevatedProcessInformation.cs" />
     <Compile Include="LoggingProvider.cs" />
     <Compile Include="ProcessInformation.cs" />

--- a/Logging/Properties/AssemblyInfo.cs
+++ b/Logging/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Logging")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("86b1d440-6f91-41aa-9c62-f1d3810dbc14")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/LsaLogonSessions/LsaLogonSessions.csproj
+++ b/LsaLogonSessions/LsaLogonSessions.csproj
@@ -79,6 +79,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="SidAttributes.cs" />
     <Compile Include="SID_AND_ATTRIBUTES.cs" />
     <Compile Include="TOKEN_GROUPS.cs" />

--- a/LsaLogonSessions/Properties/AssemblyInfo.cs
+++ b/LsaLogonSessions/Properties/AssemblyInfo.cs
@@ -27,29 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("LsaLogonSessions")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6b54ed74-c211-410c-af37-af3c6aedd8b1")]
-
-// Version information for an assembly consists of the following four values:
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/MakeMeAdmin.sln
+++ b/MakeMeAdmin.sln
@@ -24,6 +24,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteUI", "RemoteUI\Remote
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8D90453F-CDDE-4900-AC48-1DF69D948F08}"
 	ProjectSection(SolutionItems) = preProject
+		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		CONTRIBUTORS.md = CONTRIBUTORS.md
 		LICENSE = LICENSE
 	EndProjectSection

--- a/ProcessCommunication/ProcessCommunication.csproj
+++ b/ProcessCommunication/ProcessCommunication.csproj
@@ -62,6 +62,9 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="AdminGroupManipulator.cs" />
     <Compile Include="LocalAdministratorGroup.cs" />
     <Compile Include="NativeMethods.cs" />

--- a/RemoteUI/Properties/AssemblyInfo.cs
+++ b/RemoteUI/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin Remote User Interface")]
 [assembly: AssemblyDescription("Allows users to add themselves to the Administrators group on a remote computer.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d64e40bb-9dac-4491-8406-2ca2f2853f76")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/RemoteUI/RemoteUI.csproj
+++ b/RemoteUI/RemoteUI.csproj
@@ -82,6 +82,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="SubmitRequestForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Service/Properties/AssemblyInfo.cs
+++ b/Service/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin Service")]
 [assembly: AssemblyDescription("Performs administrative tasks on behalf of the user.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9e5d5515-a856-4332-bda0-ea3693da588e")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/Service/Service.csproj
+++ b/Service/Service.csproj
@@ -92,6 +92,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ProjectInstaller.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/Settings/Properties/AssemblyInfo.cs
+++ b/Settings/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin Settings Library")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8a516d69-ba38-429f-affe-c571b5c1e482")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/Settings/Settings.csproj
+++ b/Settings/Settings.csproj
@@ -68,6 +68,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/TestCode/Properties/AssemblyInfo.cs
+++ b/TestCode/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin Test Code")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ed9d4e71-a96e-4f78-8b53-2b250ab93af6")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/TestCode/TestCode.csproj
+++ b/TestCode/TestCode.csproj
@@ -82,6 +82,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/UserList/Properties/AssemblyInfo.cs
+++ b/UserList/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin User List Library")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9cfd5fa4-5ad6-463c-87e5-3f42133b5da8")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/UserList/UserList.csproj
+++ b/UserList/UserList.csproj
@@ -63,6 +63,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="User.cs" />
     <Compile Include="UserList.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UserRequestApp/LocalUI.csproj
+++ b/UserRequestApp/LocalUI.csproj
@@ -86,6 +86,9 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="RequestReasonDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/UserRequestApp/Properties/AssemblyInfo.cs
+++ b/UserRequestApp/Properties/AssemblyInfo.cs
@@ -27,31 +27,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin User Interface")]
 [assembly: AssemblyDescription("Allows users to add themselves to and remove themselves from the local Administrators group.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6ddd8596-59c3-4605-97a2-cc31edf74a90")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/WiXCustomAction/Properties/AssemblyInfo.cs
+++ b/WiXCustomAction/Properties/AssemblyInfo.cs
@@ -28,31 +28,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Make Me Admin Custom Actions")]
 [assembly: AssemblyDescription("Custom actions for the Windows Installer.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sinclair Community College")]
-[assembly: AssemblyProduct("Make Me Admin")]
-[assembly: AssemblyCopyright("Copyright © 2010-2019, Sinclair Community College")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b84efdd8-cea0-4cca-b7b8-3f8ab3a336b4")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: NeutralResourcesLanguage("en-US")]

--- a/WiXCustomAction/WiXCustomAction.csproj
+++ b/WiXCustomAction/WiXCustomAction.csproj
@@ -62,6 +62,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CustomAction.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="CustomAction.config" />


### PR DESCRIPTION
Factor out assembly information common for all projects in the solution (e.g. version numbers) into a solution-wide `CommonAssemblyInfo.cs` file to facilitate updates of this information.