### PR TITLE
Fix typo in French translation

### DIFF
--- a/UserRequestApp/MultilingualResources/LocalUI.fr.xlf
+++ b/UserRequestApp/MultilingualResources/LocalUI.fr.xlf
@@ -16,7 +16,7 @@
         </trans-unit>
         <trans-unit id="CheckingAdminStatus" translate="yes" xml:space="preserve">
           <source>Checking administrator status...</source>
-          <target state="final">Vérification du status d'administrateur...</target>
+          <target state="final">Vérification du statut d'administrateur...</target>
         </trans-unit>
         <trans-unit id="GrantRightsButtonText" translate="yes" xml:space="preserve">
           <source>Grant Me Administrator Rights</source>

--- a/UserRequestApp/Properties/Resources.fr-CA.resx
+++ b/UserRequestApp/Properties/Resources.fr-CA.resx
@@ -19,7 +19,7 @@
     <value>Make Me Admin</value>
   </data>
   <data name="CheckingAdminStatus" xml:space="preserve">
-    <value>Vérification du status d'administrateur...</value>
+    <value>Vérification du statut d'administrateur...</value>
   </data>
   <data name="GrantRightsButtonText" xml:space="preserve">
     <value>M'&amp;attribuer les droits administrateur</value>

--- a/UserRequestApp/Properties/Resources.fr.resx
+++ b/UserRequestApp/Properties/Resources.fr.resx
@@ -19,7 +19,7 @@
     <value>Make Me Admin</value>
   </data>
   <data name="CheckingAdminStatus" xml:space="preserve">
-    <value>Vérification du status d'administrateur...</value>
+    <value>Vérification du statut d'administrateur...</value>
   </data>
   <data name="GrantRightsButtonText" xml:space="preserve">
     <value>M'&amp;attribuer les droits administrateur</value>


### PR DESCRIPTION
"Statut" is the French for "status" (singular).

Thank you for developing this tool! 😄 