### PR TITLE
Adds user-facing instructions to the UI, configurable via settings/GPO.

### DIFF
--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -239,6 +239,23 @@ namespace SinclairCC.MakeMeAdmin
             */
         }
 
+        public static string[] Instructions
+        {
+            get
+            {
+                string[] policyInstructions = GetMultiString(PolicyRegistryKeyPath, null, "Instructions");
+                string[] preferenceInstructions = GetMultiString(PreferenceRegistryKeyPath, null, "Instructions");
+                if (policyInstructions != null)
+                { // The policy setting has a value. Go with whatever it says.
+                    return policyInstructions;
+                }
+                else
+                { // The preference setting has a value. Go with whatever it says.
+                    return preferenceInstructions;
+                }
+            }
+        }
+
         /// <summary>
         /// Processes the array of strings, retrieved from the registry, containing
         /// the syslog server information.

--- a/Setup/GroupPolicy/SinclairMakeMeAdmin.admx
+++ b/Setup/GroupPolicy/SinclairMakeMeAdmin.admx
@@ -393,6 +393,19 @@
 			</elements>
 		</policy>
 
-	</policies>
+    <policy name="Instructions"
+				 class="Machine"
+				 displayName="$(string.InstructionsDisplayName)"
+				 explainText="$(string.InstructionsExplainText)"
+				 key="SOFTWARE\Policies\Sinclair Community College\Make Me Admin"
+				 presentation="$(presentation.InstructionsMultiText_Presentation)" >
+      <parentCategory ref="makemeadmin:MakeMeAdmin" />
+      <supportedOn ref="windows:SUPPORTED_Windows7" />
+      <elements>
+        <multiText id="InstructionsMultiText" valueName="Instructions" required="false" maxLength="1000" maxStrings="0" />
+      </elements>
+    </policy>
+
+  </policies>
 
 </policyDefinitions>

--- a/Setup/GroupPolicy/en-US/SinclairMakeMeAdmin.adml
+++ b/Setup/GroupPolicy/en-US/SinclairMakeMeAdmin.adml
@@ -83,7 +83,10 @@
 			<string id="MaximumReasonLengthDisplayName">Maximum Reason Length</string>
 			<string id="MaximumReasonLengthExplainText">Specifies the maximum number of characters that a user may enter in the reason dialog box.</string>
 
-			<string id="None">None</string>
+      <string id="InstructionsDisplayName">Instructions</string>
+      <string id="InstructionsExplainText">Specifies instructions that will be displayed to the user in the main window.</string>
+
+      <string id="None">None</string>
 			<string id="Optional">Optional</string>
 			<string id="Required">Required</string>
 			<string id="LogElevatedProcessesDisplayName">Log Elevated Processes</string>
@@ -142,6 +145,9 @@
 				<text>Specify a security identifier (SID) or name for each user or group, along with a timeout value for each.</text>
 				<listBox refId="TimeoutOverrideListBox">SIDs or names and Timeouts:</listBox>
 			</presentation>
+      <presentation id="InstructionsMultiText_Presentation">
+        <multiTextBox refId="InstructionsMultiText">Enter instructions to be displayed to user:</multiTextBox>
+      </presentation>
 			<presentation id="SyslogMultiText_Presentation">
 				<multiTextBox refId="SyslogMultiText">Enter syslog server information.</multiTextBox>
 				<text>Syntax:</text>

--- a/UserRequestApp/MultilingualResources/LocalUI.da.xlf
+++ b/UserRequestApp/MultilingualResources/LocalUI.da.xlf
@@ -120,12 +120,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Top, Left, Right</target>
         </trans-unit>
         <trans-unit id="addMeButton.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>18, 18</source>
-          <target state="final">18, 18</target>
+          <source>12, 12</source>
+          <target state="final">12, 12</target>
         </trans-unit>
         <trans-unit id="addMeButton.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>470, 69</source>
-          <target state="final">470, 69</target>
+          <source>313, 45</source>
+          <target state="final">313, 45</target>
         </trans-unit>
         <trans-unit id="addMeButton.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
           <source>0</source>
@@ -144,12 +144,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Top, Left, Right</target>
         </trans-unit>
         <trans-unit id="removeMeButton.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>18, 100</source>
-          <target state="final">18, 100</target>
+          <source>12, 65</source>
+          <target state="final">12, 65</target>
         </trans-unit>
         <trans-unit id="removeMeButton.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>470, 69</source>
-          <target state="final">470, 69</target>
+          <source>313, 45</source>
+          <target state="final">313, 45</target>
         </trans-unit>
         <trans-unit id="removeMeButton.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
           <source>1</source>
@@ -164,8 +164,8 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Fjern nuværende Windows bruger fra Administrator gruppen.</target>
         </trans-unit>
         <trans-unit id="appStatus.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>483, 25</source>
-          <target state="final">483, 25</target>
+          <source>322, 17</source>
+          <target state="final">322, 17</target>
         </trans-unit>
         <trans-unit id="appStatus.Text" translate="yes" xml:space="preserve">
           <source>Ready.</source>
@@ -176,12 +176,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">MiddleLeft</target>
         </trans-unit>
         <trans-unit id="statusStrip1.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>0, 188</source>
-          <target state="final">0, 188</target>
+          <source>0, 122</source>
+          <target state="final">0, 122</target>
         </trans-unit>
         <trans-unit id="statusStrip1.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>506, 32</source>
-          <target state="final">506, 32</target>
+          <source>337, 22</source>
+          <target state="final">337, 22</target>
         </trans-unit>
         <trans-unit id="statusStrip1.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
           <source>2</source>
@@ -196,12 +196,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="new">Make Me Admin</target>
         </trans-unit>
         <trans-unit id="$this.AutoScaleDimensions" translate="no" extype="System.Drawing.SizeF, System.Drawing" xml:space="preserve">
-          <source>9, 20</source>
-          <target state="final">9, 20</target>
+          <source>6, 13</source>
+          <target state="final">6, 13</target>
         </trans-unit>
         <trans-unit id="$this.ClientSize" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>506, 220</source>
-          <target state="final">506, 220</target>
+          <source>337, 144</source>
+          <target state="final">337, 144</target>
         </trans-unit>
         <trans-unit id="$this.Text" translate="yes" xml:space="preserve">
           <source>Make Me Admin</source>
@@ -235,21 +235,27 @@ A reason is required in order to obtain administrator rights, but your administr
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="addMeButton.Margin" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>4, 5, 4, 5</source>
-          <target state="needs-review-translation">4, 5, 4, 5</target>
+        <trans-unit id="instructionsLabel.ImeMode" translate="yes" xml:space="preserve" extype="System.Windows.Forms.ImeMode, System.Windows.Forms">
+          <source>NoControl</source>
+          <target state="needs-review-translation">NoControl</target>
         </trans-unit>
-        <trans-unit id="removeMeButton.Margin" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>4, 5, 4, 5</source>
-          <target state="needs-review-translation">4, 5, 4, 5</target>
+        <trans-unit id="instructionsLabel.Location" translate="yes" xml:space="preserve" extype="System.Drawing.Point, System.Drawing">
+          <source>12, 118</source>
+          <target state="needs-review-translation">15, 118</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="statusStrip1.Padding" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>2, 0, 21, 0</source>
-          <target state="needs-review-translation">2, 0, 21, 0</target>
+        <trans-unit id="instructionsLabel.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+          <source>313, 0</source>
+          <target state="needs-review-translation">35, 13</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="$this.Margin" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>4, 5, 4, 5</source>
-          <target state="needs-review-translation">4, 5, 4, 5</target>
+        <trans-unit id="instructionsLabel.TabIndex" translate="yes" xml:space="preserve" extype="System.Int32, mscorlib">
+          <source>3</source>
+          <target state="needs-review-translation">3</target>
+        </trans-unit>
+        <trans-unit id="instructionsLabel.Text" translate="yes" xml:space="preserve">
+          <source>instructionsLabel</source>
+          <target state="new">instructionsLabel</target>
         </trans-unit>
       </group>
     </body>

--- a/UserRequestApp/MultilingualResources/LocalUI.fr.xlf
+++ b/UserRequestApp/MultilingualResources/LocalUI.fr.xlf
@@ -120,12 +120,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Top, Left, Right</target>
         </trans-unit>
         <trans-unit id="addMeButton.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>18, 18</source>
-          <target state="final">18, 18</target>
+          <source>12, 12</source>
+          <target state="final">12, 12</target>
         </trans-unit>
         <trans-unit id="addMeButton.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>470, 69</source>
-          <target state="final">470, 69</target>
+          <source>313, 45</source>
+          <target state="final">313, 45</target>
         </trans-unit>
         <trans-unit id="addMeButton.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
           <source>0</source>
@@ -144,12 +144,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Top, Left, Right</target>
         </trans-unit>
         <trans-unit id="removeMeButton.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>18, 100</source>
-          <target state="final">18, 100</target>
+          <source>12, 65</source>
+          <target state="final">12, 65</target>
         </trans-unit>
         <trans-unit id="removeMeButton.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>470, 69</source>
-          <target state="final">470, 69</target>
+          <source>313, 45</source>
+          <target state="final">313, 45</target>
         </trans-unit>
         <trans-unit id="removeMeButton.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
           <source>1</source>
@@ -164,8 +164,8 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Retirer l'utilisateur Windows actuel du groupe Administrateurs.</target>
         </trans-unit>
         <trans-unit id="appStatus.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>483, 25</source>
-          <target state="final">483, 25</target>
+          <source>322, 17</source>
+          <target state="final">322, 17</target>
         </trans-unit>
         <trans-unit id="appStatus.Text" translate="yes" xml:space="preserve">
           <source>Ready.</source>
@@ -176,12 +176,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">MiddleLeft</target>
         </trans-unit>
         <trans-unit id="statusStrip1.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>0, 188</source>
-          <target state="final">0, 188</target>
+          <source>0, 122</source>
+          <target state="final">0, 122</target>
         </trans-unit>
         <trans-unit id="statusStrip1.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>506, 32</source>
-          <target state="final">506, 32</target>
+          <source>337, 22</source>
+          <target state="final">337, 22</target>
         </trans-unit>
         <trans-unit id="statusStrip1.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
           <source>2</source>
@@ -196,12 +196,12 @@ A reason is required in order to obtain administrator rights, but your administr
           <target state="final">Make Me Admin</target>
         </trans-unit>
         <trans-unit id="$this.AutoScaleDimensions" translate="no" extype="System.Drawing.SizeF, System.Drawing" xml:space="preserve">
-          <source>9, 20</source>
-          <target state="final">9, 20</target>
+          <source>6, 13</source>
+          <target state="final">6, 13</target>
         </trans-unit>
         <trans-unit id="$this.ClientSize" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>506, 220</source>
-          <target state="final">506, 220</target>
+          <source>337, 144</source>
+          <target state="final">337, 144</target>
         </trans-unit>
         <trans-unit id="$this.Text" translate="no" xml:space="preserve">
           <source>Make Me Admin</source>
@@ -235,21 +235,27 @@ A reason is required in order to obtain administrator rights, but your administr
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="addMeButton.Margin" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>4, 5, 4, 5</source>
-          <target state="needs-review-translation">4, 5, 4, 5</target>
+        <trans-unit id="instructionsLabel.ImeMode" translate="yes" xml:space="preserve" extype="System.Windows.Forms.ImeMode, System.Windows.Forms">
+          <source>NoControl</source>
+          <target state="needs-review-translation">NoControl</target>
         </trans-unit>
-        <trans-unit id="removeMeButton.Margin" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>4, 5, 4, 5</source>
-          <target state="needs-review-translation">4, 5, 4, 5</target>
+        <trans-unit id="instructionsLabel.Location" translate="yes" xml:space="preserve" extype="System.Drawing.Point, System.Drawing">
+          <source>12, 118</source>
+          <target state="needs-review-translation">15, 118</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="statusStrip1.Padding" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>2, 0, 21, 0</source>
-          <target state="needs-review-translation">2, 0, 21, 0</target>
+        <trans-unit id="instructionsLabel.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+          <source>313, 0</source>
+          <target state="needs-review-translation">35, 13</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="$this.Margin" translate="yes" xml:space="preserve" extype="System.Windows.Forms.Padding, System.Windows.Forms">
-          <source>4, 5, 4, 5</source>
-          <target state="needs-review-translation">4, 5, 4, 5</target>
+        <trans-unit id="instructionsLabel.TabIndex" translate="yes" xml:space="preserve" extype="System.Int32, mscorlib">
+          <source>3</source>
+          <target state="needs-review-translation">3</target>
+        </trans-unit>
+        <trans-unit id="instructionsLabel.Text" translate="yes" xml:space="preserve">
+          <source>instructionsLabel</source>
+          <target state="new">instructionsLabel</target>
         </trans-unit>
       </group>
     </body>

--- a/UserRequestApp/SubmitRequestForm.Designer.cs
+++ b/UserRequestApp/SubmitRequestForm.Designer.cs
@@ -76,6 +76,11 @@ namespace SinclairCC.MakeMeAdmin
         private System.Windows.Forms.NotifyIcon notifyIcon;
 
         /// <summary>
+        /// instructions label
+        /// </summary>
+        private System.Windows.Forms.Label instructionsLabel;
+
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -108,6 +113,7 @@ namespace SinclairCC.MakeMeAdmin
             this.addUserBackgroundWorker = new System.ComponentModel.BackgroundWorker();
             this.removeUserBackgroundWorker = new System.ComponentModel.BackgroundWorker();
             this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+            this.instructionsLabel = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -165,10 +171,16 @@ namespace SinclairCC.MakeMeAdmin
             this.notifyIcon.BalloonTipClosed += new System.EventHandler(this.notifyIcon_BalloonTipClosed);
             this.notifyIcon.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon_MouseDoubleClick);
             // 
+            // instructionsLabel
+            // 
+            resources.ApplyResources(this.instructionsLabel, "instructionsLabel");
+            this.instructionsLabel.Name = "instructionsLabel";
+            // 
             // SubmitRequestForm
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.instructionsLabel);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.removeMeButton);
             this.Controls.Add(this.addMeButton);

--- a/UserRequestApp/SubmitRequestForm.cs
+++ b/UserRequestApp/SubmitRequestForm.cs
@@ -21,6 +21,7 @@
 namespace SinclairCC.MakeMeAdmin
 {
     using System;
+    using System.Drawing;
     using System.Reflection;
     using System.Security.Principal;
     using System.ServiceModel;
@@ -73,6 +74,7 @@ namespace SinclairCC.MakeMeAdmin
             this.notifyIcon.Icon = Properties.Resources.SecurityLock;
 
             this.SetFormText();
+            this.SetInstructions();
 
             // Configure the notification timer.
             this.notifyIconTimer = new System.Timers.Timer()
@@ -137,6 +139,24 @@ namespace SinclairCC.MakeMeAdmin
 
             this.Text = formText.ToString();
             this.notifyIcon.Text = formText.ToString();
+        }
+
+
+        /// <summary>
+        /// Sets the instructions label to the value specified in Settings.
+        /// </summary>
+        private void SetInstructions()
+        {
+            this.instructionsLabel.Text = string.Join(Environment.NewLine, Settings.Instructions);
+
+            // Calculate the preferred label height based on the content and maximum width
+            int preferredHeight = TextRenderer.MeasureText(instructionsLabel.Text, instructionsLabel.Font, new Size(instructionsLabel.Width, int.MaxValue), TextFormatFlags.WordBreak).Height;
+
+            // Set the calculated height for the label
+            instructionsLabel.Height = preferredHeight;
+
+            // Set the calculated height for the form
+            this.Height = this.Height + preferredHeight;
         }
 
 

--- a/UserRequestApp/SubmitRequestForm.da.resx
+++ b/UserRequestApp/SubmitRequestForm.da.resx
@@ -27,16 +27,16 @@
   <data name="appStatus.Text" xml:space="preserve">
     <value>Klar.</value>
   </data>
-  <data name="addMeButton.Margin" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="instructionsLabel.ImeMode" xml:space="preserve" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="removeMeButton.Margin" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="instructionsLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>15, 118</value>
   </data>
-  <data name="statusStrip1.Padding" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 21, 0</value>
+  <data name="instructionsLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>35, 13</value>
   </data>
-  <data name="$this.Margin" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="instructionsLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
 </root>

--- a/UserRequestApp/SubmitRequestForm.fr.resx
+++ b/UserRequestApp/SubmitRequestForm.fr.resx
@@ -27,16 +27,16 @@
   <data name="appStatus.Text" xml:space="preserve">
     <value>Prêt.</value>
   </data>
-  <data name="addMeButton.Margin" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="instructionsLabel.ImeMode" xml:space="preserve" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="removeMeButton.Margin" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="instructionsLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>15, 118</value>
   </data>
-  <data name="statusStrip1.Padding" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 21, 0</value>
+  <data name="instructionsLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>35, 13</value>
   </data>
-  <data name="$this.Margin" xml:space="preserve" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="instructionsLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
 </root>

--- a/UserRequestApp/SubmitRequestForm.resx
+++ b/UserRequestApp/SubmitRequestForm.resx
@@ -123,13 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="addMeButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 18</value>
-  </data>
-  <data name="addMeButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>12, 12</value>
   </data>
   <data name="addMeButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>470, 69</value>
+    <value>313, 45</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="addMeButton.TabIndex" type="System.Int32, mscorlib">
@@ -154,19 +151,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;addMeButton.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="removeMeButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="removeMeButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 100</value>
-  </data>
-  <data name="removeMeButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>12, 65</value>
   </data>
   <data name="removeMeButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>470, 69</value>
+    <value>313, 45</value>
   </data>
   <data name="removeMeButton.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -187,13 +181,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;removeMeButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>354, 17</value>
   </metadata>
   <data name="appStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>483, 25</value>
+    <value>322, 17</value>
   </data>
   <data name="appStatus.Text" xml:space="preserve">
     <value>Ready.</value>
@@ -202,13 +196,10 @@
     <value>MiddleLeft</value>
   </data>
   <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 188</value>
-  </data>
-  <data name="statusStrip1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 21, 0</value>
+    <value>0, 122</value>
   </data>
   <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>506, 32</value>
+    <value>337, 22</value>
   </data>
   <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -226,7 +217,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;statusStrip1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <metadata name="buttonStateWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>136, 17</value>
@@ -243,17 +234,41 @@
   <data name="notifyIcon.Text" xml:space="preserve">
     <value>Make Me Admin</value>
   </data>
+  <data name="instructionsLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="instructionsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 118</value>
+  </data>
+  <data name="instructionsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>313, 0</value>
+  </data>
+  <data name="instructionsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="instructionsLabel.Text" xml:space="preserve">
+    <value>instructionsLabel</value>
+  </data>
+  <data name="&gt;&gt;instructionsLabel.Name" xml:space="preserve">
+    <value>instructionsLabel</value>
+  </data>
+  <data name="&gt;&gt;instructionsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;instructionsLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;instructionsLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>506, 220</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>337, 144</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Make Me Admin</value>


### PR DESCRIPTION
As a user of the tool as deployed by our organization, I've noticed that without in-app instructions, it can be frustrating to use the app with some of the idiosyncrasies introduced by our environment (e.g. the need to "Run as different user").  The ability to configure instructions particular to one's own set of users would be helpful.  

![image](https://github.com/pseymour/MakeMeAdmin/assets/146997224/5b482691-366b-46f1-83b4-3e237978192d)
